### PR TITLE
Make the qr code easier readable by qr code scanners

### DIFF
--- a/foerder.html
+++ b/foerder.html
@@ -378,7 +378,7 @@
 				formDict[pair[0]] = pair[1];
 			}
 
-			var jsonMsg = JSON.stringify(formDict);
+			var jsonMsg = window.btoa(JSON.stringify(formDict));
 			console.log(jsonMsg);
 
 			var qr = new QRious({


### PR DESCRIPTION
For some reason if there are too many quotes (") in the encoded string
qr scanners have a hard time decoding it. Easy quick fix is to base64
encode the string. It's longer, but read reliably.

This is related to the idea to compress the string with zip. That would add another external dependency, which we would need to keep updated etc. base64 encoding is basic JavaScript functionality. Also users of the form have an easier time to find out what the qr code is encoding. Because of these reasons I'm fine with base64, even though it's probably longer than zip compressed text.